### PR TITLE
Add parsing for custom db functions

### DIFF
--- a/src/parser/special-functions.ts
+++ b/src/parser/special-functions.ts
@@ -11,7 +11,10 @@ export function specialFunctionCall(primaryExpr: Parser<Expression>) {
     argsParser: Parser<Expression[]>
   ) {
     return seq(
-      (_, argList) => Expression.createFunctionCall(funcName, argList),
+      (_, argList) => Expression.createFunctionCall(
+        Expression.FunctionCallRef.create(null, funcName),
+        argList
+      ),
       expectIdentifier(funcName),
       parenthesized(argsParser)
     )


### PR DESCRIPTION
NOT FINISHED WORK.

The goal is to add support for determining nullability and result row count for custom database functions.

```typescript
// Desired output
export async function signUp(
    client: ClientBase,
    params: { emailAddress: string },
): Promise<{
    id: string;
    emailAddress: string;
    accessLevel: 'GUEST' | 'AGENT';
    refreshToken: Buffer;
}> { ... }

// Current output
export async function signUp(
    client: ClientBase,
    params: { emailAddress: string },
): Promise<
    Array<{
        id: string | null;
        emailAddress: string | null;
        accessLevel: 'GUEST' | 'AGENT' | null;
        refreshToken: Buffer | null;
    }>
> { ... }
```

Internally `sqltyper` works so that it introspects the query against postgres and then does some own parsing to determine the nullability and the amount or rows returned (many | zeroOrOne | one | zero). Introspecting return types seems to work already even when querying custom functions but the nullability and row count is missing. Also a warning is generated.

The first step is to get the parser to recognize custom functions. That part is done. The next step is to apply the nullability and return row count checks on those functions. That part is still missing.